### PR TITLE
Make sure number of newlines are counted correctly.

### DIFF
--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -178,7 +178,7 @@ class AtfLexer(object):
 
     # In the base state, a newline doesn't change state
     def t_NEWLINE(self, t):
-        r'\s*[\n\r]'
+        r'[ \t\f\v]*[\n\r]'
         t.lexer.lineno += 1
         return t
 

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -178,8 +178,8 @@ class AtfLexer(object):
 
     # In the base state, a newline doesn't change state
     def t_NEWLINE(self, t):
-        r'[ \t\f\v]*[\n\r]'
-        t.lexer.lineno += 1
+        r'\s*[\n\r]'
+        t.lexer.lineno += t.value.count("\n")
         return t
 
     def t_INITIAL_parallel_labeled_ATID(self, t):
@@ -346,14 +346,14 @@ class AtfLexer(object):
     # A newline followed by a space gives continuation
     def t_parallel_NEWLINE(self, t):
         r'\s*[\n\r](?![ \t])'
-        t.lexer.lineno += 1
+        t.lexer.lineno += t.value.count("\n")
         return t
 
     # In interlinear states, a newline which is not continuation leaves state
     # A newline followed by a space gives continuation
     def t_interlinear_NEWLINE(self, t):
         r'\s*[\n\r](?![ \t])'
-        t.lexer.lineno += 1
+        t.lexer.lineno += t.value.count("\n")
         t.lexer.pop_state()
         return t
 
@@ -361,7 +361,7 @@ class AtfLexer(object):
     # A newline just passed through
     def t_labeled_NEWLINE(self, t):
         r'\s*[\n\r]'
-        t.lexer.lineno += 1
+        t.lexer.lineno += t.value.count("\n")
         return t
 
     # Flag characters (#! etc ) don't apply in translations
@@ -444,7 +444,7 @@ class AtfLexer(object):
     # Translation paragraph state is ended by a double newline
     @lex.TOKEN(r'[\n\r](?=' + terminates_paragraph + ')')
     def t_para_MAGICNEWLINE(self, t):
-        t.lexer.lineno += 1
+        t.lexer.lineno += t.value.count("\n")
         t.lexer.pop_state()
         t.type = "NEWLINE"
         return t

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -16,12 +16,16 @@ class testLexer(TestCase):
     def setUp(self):
         self.lexer = AtfLexer().lexer
 
-    def compare_tokens(self, content, expected_types, expected_values=None):
+    def compare_tokens(self, content, expected_types, expected_values=None,
+                       expected_lineno=None):
         self.lexer.input(content)
         if expected_values is None:
             expected_values = repeat(None)
-        for expected_type, expected_value, token in zip_longest(
-                expected_types, expected_values, self.lexer):
+        if expected_lineno is None:
+            expected_lineno = repeat(None)
+        for expected_type, expected_value, expected_lineno, token in \
+                zip_longest(expected_types, expected_values, expected_lineno,
+                            self.lexer):
             print(token, expected_type)
             if token is None and expected_type is None:
                 break
@@ -29,6 +33,8 @@ class testLexer(TestCase):
             if expected_value:
                 # print token.value, expected_value
                 assert token.value == expected_value
+            if expected_lineno:
+                assert token.lineno == expected_lineno
 
     def test_code(self):
         self.compare_tokens(
@@ -773,8 +779,7 @@ class testLexer(TestCase):
         self.compare_tokens(
             "@obverse\n" +
             "\n" +
-            '#note: The CAD translation šarriru = "humble",\n',
-            ["OBVERSE", "NEWLINE"] +
-            ["NEWLINE"] +
-            ["NOTE", "ID", "NEWLINE"]
-            )
+            "#note:\n",
+            ["OBVERSE", "NEWLINE", "NOTE", "NEWLINE"],
+            ["obverse", "\n\n", "note", "\n"],
+            [1, 1, 3, 3])

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -768,3 +768,13 @@ class testLexer(TestCase):
              "OBVERSE", "NEWLINE",
              "INCLUDE", "ID", 'EQUALS', 'ID', "NEWLINE"]
         )
+
+    def test_double_newline(self):
+        self.compare_tokens(
+            "@obverse\n" +
+            "\n" +
+            '#note: The CAD translation šarriru = "humble",\n',
+            ["OBVERSE", "NEWLINE"] +
+            ["NEWLINE"] +
+            ["NOTE", "ID", "NEWLINE"]
+            )


### PR DESCRIPTION
If there is more than one newline \s* will match all but one of them. This breaks syntax
highlighting since the line number counter will be off. Here we simply solve that be counting the number of newlines in the token value 