### PR TITLE
Allow lexing of invalid syntax

### DIFF
--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -507,7 +507,7 @@ class AtfLexer(object):
     # Error handling rule
     def t_ANY_error(self, t):
         formatstring = u"Illegal character '{}'".format(t.value[0])
-        if skipinvalid:
+        if self.skipinvalid:
             t.lexer.skip(1)
             print(formatstring)
         else:

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -335,14 +335,6 @@ class AtfLexer(object):
             # the keywords refering to structural elements in strict dollar
             # lines must be DIFFERENT TOKENS IN THE LEXER
             t.type = "REFERENCE"
-
-        if t.type is None:
-            formatstring = u"Invalid ID '{}'".format(t.value)
-            if self.skipinvalid:
-                print(formatstring)
-                return
-            else:
-                raise SyntaxError(formatstring)
         return t
 
     def t_parallel_LINELABEL(self, t):

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -213,7 +213,7 @@ class AtfLexer(object):
         if t.type in AtfLexer.long_argument_structures + ["NOTE"]:
             t.lexer.push_state('flagged')
         if t.type is None:
-            formatstring = "Illegal @STRING '{}'".format(t.value)
+            formatstring = u"Illegal @STRING '{}'".format(t.value)
             if self.skipinvalid:
                 print(formatstring)
                 return
@@ -247,7 +247,7 @@ class AtfLexer(object):
         if t.type == "NOTE":
             t.lexer.push_state('para')
         if t.type is None:
-            formatstring = "Illegal #STRING '{}'".format(t.value)
+            formatstring = u"Illegal #STRING '{}'".format(t.value)
             if self.skipinvalid:
                 print(formatstring)
                 return
@@ -293,7 +293,7 @@ class AtfLexer(object):
             t.type = "REFERENCE"
 
         if t.type is None:
-            formatstring = "ID '{}'".format(t.value)
+            formatstring = u"ID '{}'".format(t.value)
             if self.skipinvalid:
                 print(formatstring)
                 return
@@ -345,7 +345,7 @@ class AtfLexer(object):
             t.type = "REFERENCE"
 
         if t.type is None:
-            formatstring = "Invalid ID '{}'".format(t.value)
+            formatstring = u"Invalid ID '{}'".format(t.value)
             if self.skipinvalid:
                 print(formatstring)
                 return
@@ -506,7 +506,7 @@ class AtfLexer(object):
 
     # Error handling rule
     def t_ANY_error(self, t):
-        formatstring = "Illegal character '{}'".format(t.value[0])
+        formatstring = u"Illegal character '{}'".format(t.value[0])
         if skipinvalid:
             t.lexer.skip(1)
             print(formatstring)

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -291,14 +291,6 @@ class AtfLexer(object):
             # the keywords refering to structural elements in strict dollar
             # lines must be DIFFERENT TOKENS IN THE LEXER
             t.type = "REFERENCE"
-
-        if t.type is None:
-            formatstring = u"ID '{}'".format(t.value)
-            if self.skipinvalid:
-                print(formatstring)
-                return
-            else:
-                raise SyntaxError(formatstring)
         return t
 
     # In the flagged, text, transctrl and lemmatize states,

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -798,7 +798,7 @@ class testLexer(TestCase):
             pass
 
     def test_invalid_hash_raises_syntax_error(self):
-        string = "#lems: Ṣalbatanu[Mars]CN\n"
+        string = u"#lems: Ṣalbatanu[Mars]CN\n"
         self.lexer.input(string)
         with pytest.raises(SyntaxError) as excinfo:
             for i in self.lexer:

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -791,10 +791,20 @@ class testLexer(TestCase):
         with pytest.raises(SyntaxError) as excinfo:
             for i in self.lexer:
                 pass
+        # If we allow invalid syntax this should not raise
+        self.lexer = AtfLexer(skipinvalid=True).lexer
+        self.lexer.input(string)
+        for i in self.lexer:
+            pass
 
     def test_invalid_hash_raises_syntax_error(self):
-        string = "#lems:\n"
+        string = "#lems: Ṣalbatanu[Mars]CN\n"
         self.lexer.input(string)
         with pytest.raises(SyntaxError) as excinfo:
             for i in self.lexer:
                 pass
+        # If we allow invalid syntax this should not raise
+        self.lexer = AtfLexer(skipinvalid=True).lexer
+        self.lexer.input(string)
+        for i in self.lexer:
+            pass

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -808,3 +808,15 @@ class testLexer(TestCase):
         self.lexer.input(string)
         for i in self.lexer:
             pass
+
+    def test_invalid_id_syntax_error(self):
+        string = u"Ṣalbatanu[Mars]CN\n"
+        self.lexer.input(string)
+        with pytest.raises(SyntaxError) as excinfo:
+            for i in self.lexer:
+                pass
+        # If we allow invalid syntax this should not raise
+        self.lexer = AtfLexer(skipinvalid=True).lexer
+        self.lexer.input(string)
+        for i in self.lexer:
+            pass

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import sys
 from itertools import repeat
 from unittest import TestCase
+import pytest
 from ...atf.atflex import AtfLexer
 # Jython does not use a named touple here so we have to just take the first
 # element and not major as normal.
@@ -783,3 +784,17 @@ class testLexer(TestCase):
             ["OBVERSE", "NEWLINE", "NOTE", "NEWLINE"],
             ["obverse", "\n\n", "note", "\n"],
             [1, 1, 3, 3])
+
+    def test_invalid_at_raises_syntax_error(self):
+        string = "@obversel\n"
+        self.lexer.input(string)
+        with pytest.raises(SyntaxError) as excinfo:
+            for i in self.lexer:
+                pass
+
+    def test_invalid_hash_raises_syntax_error(self):
+        string = "#lems:\n"
+        self.lexer.input(string)
+        with pytest.raises(SyntaxError) as excinfo:
+            for i in self.lexer:
+                pass

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -37,6 +37,17 @@ class testLexer(TestCase):
             if expected_lineno:
                 assert token.lineno == expected_lineno
 
+    def ensure_raises_and_not(self, string):
+        self.lexer.input(string)
+        with pytest.raises(SyntaxError) as excinfo:
+            for i in self.lexer:
+                pass
+        # If we allow invalid syntax this should not raise
+        self.lexer = AtfLexer(skipinvalid=True).lexer
+        self.lexer.input(string)
+        for i in self.lexer:
+            pass
+
     def test_code(self):
         self.compare_tokens(
             "&X001001 = JCS 48, 089\n",
@@ -787,36 +798,12 @@ class testLexer(TestCase):
 
     def test_invalid_at_raises_syntax_error(self):
         string = "@obversel\n"
-        self.lexer.input(string)
-        with pytest.raises(SyntaxError) as excinfo:
-            for i in self.lexer:
-                pass
-        # If we allow invalid syntax this should not raise
-        self.lexer = AtfLexer(skipinvalid=True).lexer
-        self.lexer.input(string)
-        for i in self.lexer:
-            pass
+        self.ensure_raises_and_not(string)
 
     def test_invalid_hash_raises_syntax_error(self):
         string = u"#lems: Ṣalbatanu[Mars]CN\n"
-        self.lexer.input(string)
-        with pytest.raises(SyntaxError) as excinfo:
-            for i in self.lexer:
-                pass
-        # If we allow invalid syntax this should not raise
-        self.lexer = AtfLexer(skipinvalid=True).lexer
-        self.lexer.input(string)
-        for i in self.lexer:
-            pass
+        self.ensure_raises_and_not(string)
 
     def test_invalid_id_syntax_error(self):
         string = u"Ṣalbatanu[Mars]CN\n"
-        self.lexer.input(string)
-        with pytest.raises(SyntaxError) as excinfo:
-            for i in self.lexer:
-                pass
-        # If we allow invalid syntax this should not raise
-        self.lexer = AtfLexer(skipinvalid=True).lexer
-        self.lexer.input(string)
-        for i in self.lexer:
-            pass
+        self.ensure_raises_and_not(string)


### PR DESCRIPTION
When syntax highlighting we don't want to error out on a invalid token. The token may be invalid as you type since you will have partially entered tokens in the file. To work around this I changed the code to make sure that it always trows Syntax errors on missing tokens. The syntax errors can optionally be skipped and replaced by warnings prints.