### PR TITLE
Correct lexer pos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
         pip install --upgrade pip
         pip install --upgrade wheel
         pip install --upgrade setuptools
-        pip install ply pep8 mako pytest
+        pip install --upgrade ply pep8 mako pytest
         if [ "$MYPYTHON" == "python" ]; then
           pip install pytest-cov codecov
         fi

--- a/pyoracc/__init__.py
+++ b/pyoracc/__init__.py
@@ -1,5 +1,6 @@
 import sys
 
+
 def _generate_parsetab():
     """
     Simple function to generate a parsetab file. This is done by creating a

--- a/pyoracc/__init__.py
+++ b/pyoracc/__init__.py
@@ -1,3 +1,5 @@
+import sys
+
 def _generate_parsetab():
     """
     Simple function to generate a parsetab file. This is done by creating a
@@ -5,3 +7,17 @@ def _generate_parsetab():
     """
     from pyoracc.atf.atfyacc import AtfParser
     myparser = AtfParser()
+
+
+def _pyversion():
+    """
+    Are we on Python 2 or 3
+    Do this in an as simple as possible way to ensure that it works with old
+    versions of Jython too.
+    Jython does not use a named touple here so we have to just take the first
+    element and not major as normal.
+    """
+    if sys.version_info[0] == 2:
+        return 2
+    else:
+        return 3

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -6,6 +6,7 @@ import re
 import warnings
 from pyoracc import _pyversion
 
+
 class AtfLexer(object):
 
     def _keyword_dict(self, tokens, extra):

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -183,7 +183,7 @@ class AtfLexer(object):
     def t_INITIAL_parallel_labeled_ATID(self, t):
         '\@[a-zA-Z][a-zA-Z0-9\[\]]*\+?'
         t.value = t.value[1:]
-
+        t.lexpos += 1
         t.type = self.resolve_keyword(t.value,
                                       AtfLexer.structures +
                                       AtfLexer.long_argument_structures,
@@ -231,6 +231,7 @@ class AtfLexer(object):
         '\#[a-zA-Z][a-zA-Z0-9\[\]]+\:'
         # Note that \:? absorbs a trailing colon in protocol keywords
         t.value = t.value[1:-1]
+        t.lexpos += 1
         t.type = self.resolve_keyword(t.value,
                                       AtfLexer.protocols,
                                       extra={'CHECK': 'CHECK'})

--- a/pyoracc/atf/atflex.py
+++ b/pyoracc/atf/atflex.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import ply.lex as lex
 import re
-
+import warnings
+from pyoracc import _pyversion
 
 class AtfLexer(object):
 
@@ -214,8 +216,10 @@ class AtfLexer(object):
             t.lexer.push_state('flagged')
         if t.type is None:
             formatstring = u"Illegal @STRING '{}'".format(t.value)
+            if _pyversion() == 2:
+                formatstring = formatstring.encode('UTF-8')
             if self.skipinvalid:
-                print(formatstring)
+                warnings.warn(formatstring, UserWarning)
                 return
             else:
                 raise SyntaxError(formatstring)
@@ -249,8 +253,10 @@ class AtfLexer(object):
             t.lexer.push_state('para')
         if t.type is None:
             formatstring = u"Illegal #STRING '{}'".format(t.value)
+            if _pyversion() == 2:
+                formatstring = formatstring.encode('UTF-8')
             if self.skipinvalid:
-                print(formatstring)
+                warnings.warn(formatstring, UserWarning)
                 return
             else:
                 raise SyntaxError(formatstring)
@@ -492,9 +498,11 @@ class AtfLexer(object):
     # Error handling rule
     def t_ANY_error(self, t):
         formatstring = u"Illegal character '{}'".format(t.value[0])
+        if _pyversion() == 2:
+            formatstring = formatstring.encode('UTF-8')
         if self.skipinvalid:
             t.lexer.skip(1)
-            print(formatstring)
+            warnings.warn(formatstring, UserWarning)
         else:
             raise SyntaxError(formatstring)
 

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -18,24 +18,30 @@ class testLexer(TestCase):
         self.lexer = AtfLexer().lexer
 
     def compare_tokens(self, content, expected_types, expected_values=None,
-                       expected_lineno=None):
+                       expected_lineno=None, expected_lexpos=None):
         self.lexer.input(content)
         if expected_values is None:
             expected_values = repeat(None)
         if expected_lineno is None:
             expected_lineno = repeat(None)
-        for expected_type, expected_value, expected_lineno, token in \
-                zip_longest(expected_types, expected_values, expected_lineno,
+        if expected_lexpos is None:
+            expected_lexpos = repeat(None)
+        for e_type, e_value, e_lineno, e_lexpos, token in zip_longest(
+                            expected_types,
+                            expected_values,
+                            expected_lineno,
+                            expected_lexpos,
                             self.lexer):
-            print(token, expected_type)
-            if token is None and expected_type is None:
+            print(token, e_type)
+            if token is None and e_type is None:
                 break
-            assert token.type == expected_type
-            if expected_value:
-                # print token.value, expected_value
-                assert token.value == expected_value
-            if expected_lineno:
-                assert token.lineno == expected_lineno
+            assert token.type == e_type
+            if e_value:
+                assert token.value == e_value
+            if e_lineno:
+                assert token.lineno == e_lineno
+            if e_lexpos:
+                assert token.lexpos == e_lexpos
 
     def ensure_raises_and_not(self, string):
         self.lexer.input(string)
@@ -787,14 +793,15 @@ class testLexer(TestCase):
              "INCLUDE", "ID", 'EQUALS', 'ID', "NEWLINE"]
         )
 
-    def test_double_newline(self):
+    def test_double_newline_and_lexpos(self):
         self.compare_tokens(
             "@obverse\n" +
             "\n" +
             "#note:\n",
             ["OBVERSE", "NEWLINE", "NOTE", "NEWLINE"],
             ["obverse", "\n\n", "note", "\n"],
-            [1, 1, 3, 3])
+            [1, 1, 3, 3],
+            [1, 8, 11, 16])
 
     def test_invalid_at_raises_syntax_error(self):
         string = "@obversel\n"

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -6,10 +6,7 @@ from unittest import TestCase
 import pytest
 from ...atf.atflex import AtfLexer
 from pyoracc import _pyversion
-
-pyversion = _pyversion()
-
-if pyversion == 2:
+if _pyversion() == 2:
     from itertools import izip_longest as zip_longest
 else:
     from itertools import zip_longest
@@ -808,12 +805,12 @@ class testLexer(TestCase):
 
     def test_invalid_at_raises_syntax_error(self):
         string = u"@obversel\n"
-        self.ensure_raises_and_not(string, 1)
+        self.ensure_raises_and_not(string, nwarnings=1)
 
     def test_invalid_hash_raises_syntax_error(self):
         string = u"#lems: Ṣalbatanu[Mars]CN\n"
-        self.ensure_raises_and_not(string, 2)
+        self.ensure_raises_and_not(string, nwarnings=2)
 
     def test_invalid_id_syntax_error(self):
         string = u"Ṣalbatanu[Mars]CN\n"
-        self.ensure_raises_and_not(string, 1)
+        self.ensure_raises_and_not(string, nwarnings=1)

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -32,7 +32,6 @@ class testLexer(TestCase):
                 expected_lineno,
                 expected_lexpos,
                 self.lexer):
-            print(token, e_type)
             if token is None and e_type is None:
                 break
             assert token.type == e_type

--- a/pyoracc/test/atf/test_atflexer.py
+++ b/pyoracc/test/atf/test_atflexer.py
@@ -27,11 +27,11 @@ class testLexer(TestCase):
         if expected_lexpos is None:
             expected_lexpos = repeat(None)
         for e_type, e_value, e_lineno, e_lexpos, token in zip_longest(
-                            expected_types,
-                            expected_values,
-                            expected_lineno,
-                            expected_lexpos,
-                            self.lexer):
+                expected_types,
+                expected_values,
+                expected_lineno,
+                expected_lexpos,
+                self.lexer):
             print(token, e_type)
             if token is None and e_type is None:
                 break


### PR DESCRIPTION
This sits on top of #35 which should be reviewed first. 

Tokens starting with `#` and `@` are cutting of the first element of the token. This means that the lexerpos will be one off when syntax highlighting. This corrects that by updating the lexer position. 